### PR TITLE
Support loading modules like Foo::Bar

### DIFF
--- a/lib/Bot/BasicBot/Pluggable.pm
+++ b/lib/Bot/BasicBot/Pluggable.pm
@@ -89,7 +89,7 @@ sub load {
     my $logger = Log::Log4perl->get_logger( ref $self );
 
     # it's safe to die here, mostly this call is eval'd.
-    $logger->logdie("Cannot load module with a name") unless $module;
+    $logger->logdie("Cannot load module without a name") unless $module;
     $logger->logdie("Module $module already loaded") if $self->handler($module);
 
     # This is possible a leeeetle bit evil.

--- a/lib/Bot/BasicBot/Pluggable.pm
+++ b/lib/Bot/BasicBot/Pluggable.pm
@@ -94,10 +94,13 @@ sub load {
 
     # This is possible a leeeetle bit evil.
     $logger->info("Loading module $module");
-    my $file = "Bot/BasicBot/Pluggable/Module/$module.pm";
-    $file = "./$module.pm"         if ( -e "./$module.pm" );
-    $file = "./modules/$module.pm" if ( -e "./modules/$module.pm" );
+    my $filename = $module;
+    $filename =~ s{::}{/}g;
+    my $file = "Bot/BasicBot/Pluggable/Module/$filename.pm";
+    $file = "./$filename.pm"         if ( -e "./$filename.pm" );
+    $file = "./modules/$filename.pm" if ( -e "./modules/$filename.pm" );
     $logger->debug("Loading module $module from file $file");
+    warn "Loading $module from $file";
 
     # force a reload of the file (in the event that we've already loaded it).
     no warnings 'redefine';


### PR DESCRIPTION
Currently, you can't load a module like `Bot::BasicBot::Pluggable::Module::Foo::Bar` by saying `$bot->load('Foo::Bar')` as it tries to load e.g. `Bot/BasicBot/Pluggable/Module/Foo::Bar.pm`.

This pull request makes that work.

(Also, a typo fix in an error message thrown in, as it caught my eye as I was reading that code.)
