### PR TITLE
Add ability for 'Seen' module to hide private channels

### DIFF
--- a/lib/Bot/BasicBot/Pluggable.pm
+++ b/lib/Bot/BasicBot/Pluggable.pm
@@ -89,15 +89,18 @@ sub load {
     my $logger = Log::Log4perl->get_logger( ref $self );
 
     # it's safe to die here, mostly this call is eval'd.
-    $logger->logdie("Cannot load module with a name") unless $module;
+    $logger->logdie("Cannot load module without a name") unless $module;
     $logger->logdie("Module $module already loaded") if $self->handler($module);
 
     # This is possible a leeeetle bit evil.
     $logger->info("Loading module $module");
-    my $file = "Bot/BasicBot/Pluggable/Module/$module.pm";
-    $file = "./$module.pm"         if ( -e "./$module.pm" );
-    $file = "./modules/$module.pm" if ( -e "./modules/$module.pm" );
+    my $filename = $module;
+    $filename =~ s{::}{/}g;
+    my $file = "Bot/BasicBot/Pluggable/Module/$filename.pm";
+    $file = "./$filename.pm"         if ( -e "./$filename.pm" );
+    $file = "./modules/$filename.pm" if ( -e "./modules/$filename.pm" );
     $logger->debug("Loading module $module from file $file");
+    warn "Loading $module from $file";
 
     # force a reload of the file (in the event that we've already loaded it).
     no warnings 'redefine';

--- a/lib/Bot/BasicBot/Pluggable/Module/Seen.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Seen.pm
@@ -12,7 +12,14 @@ sub init {
 
 sub help {
     return
-"Tracks when and where people were seen. Usage: seen <nick>, hide, unhide.";
+"Tracks when and where people were last seen. 
+Usage:
+seen <nick>    (find out where 'nick' was last seen)
+hide           (Start hiding yourself from 'seen' reporting)
+unhide         (Stop  hiding yourself from 'seen' reporting)
+hidechan #chan (Hide a private channel from seen reporting)
+showchan #chan (Stop hiding a private channel from seen reporting)
+";
 }
 
 sub seen {

--- a/lib/Bot/BasicBot/Pluggable/Module/Seen.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Seen.pm
@@ -14,11 +14,11 @@ sub help {
     return
 "Tracks when and where people were last seen. 
 Usage:
-seen <nick>    (find out where 'nick' was last seen)
-hide           (Start hiding yourself from 'seen' reporting)
-unhide         (Stop  hiding yourself from 'seen' reporting)
-hidechan #chan (Hide a private channel from seen reporting)
-showchan #chan (Stop hiding a private channel from seen reporting)
+seen <nick>      (find out where 'nick' was last seen)
+hide             (Start hiding yourself from 'seen' reporting)
+unhide           (Stop  hiding yourself from 'seen' reporting)
+hidechan   #chan (Hide a private channel from seen reporting)
+unhidechan #chan (Stop hiding a private channel from seen reporting)
 ";
 }
 
@@ -101,7 +101,7 @@ sub told {
         $self->unset("hide_$nick");
         return "Ok, you're visible to seen status.";
     }
-    elsif ( my ($chanhideaction) = $command =~ /(show|hide)chan/ ) {
+    elsif ( my ($chanhideaction) = $command =~ /^(hide|unhide)chan$/ ) {
         my $response;
         if ($self->authed($mess->{who})) {
             my $ignore_channels = $self->get('user_ignore_channels') || {};


### PR DESCRIPTION
Currently, if a bot sits in both 'private' and public channels, it could leak information from a private channel to a public one if the `Seen` module is enabled.

Contrived example:

```
<user> seen: bob
<bot> bob was last seen in #super-secret 2 days 8 hours ago saying "Something very sensitive"
```

This pull request adds the ability to tell the bot not to record things said by users on private channels with the new `hidechan` command:

```
00:08 < bigpresh> sophie: hidechan #secret-channel
00:08 < botname> bigpresh: OK, not tracking users in #secret-channel
```

This can be undone with the `unhidechan` command.

Also, when the last seen status is fetched, if it was in a channel which should be hidden (because the channel wasn't hidden at the time, and the user hasn't done anything since), the bot will deny having seen the user, as it would if the user was marked as hidden from 'seen'.

Hope you'll consider incorporating this feature.
