### PR TITLE
Avoid an undefined value warning in ChanOp

### DIFF
--- a/lib/Bot/BasicBot/Pluggable/Module/ChanOp.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/ChanOp.pm
@@ -19,7 +19,9 @@ sub isop {
     my ( $self, $channel, $who ) = @_;
     return unless $channel;
     $who ||= $self->bot->nick();
-    return $self->bot->channel_data($channel)->{$who}->{op};
+    my $channel_data = $self->bot->channel_data($channel)
+        or return;
+    return $channel_data($channel)->{$who}->{op};
 }
 
 sub deop_op {


### PR DESCRIPTION
Fixes a undefined value warning when ChanOp tries to dereference the return from `$self->bot->channel_data()`:

```
WARN   2011/10/07 11:15:08 Can't use an undefined value as a HASH reference at
/home/davidp/dev/github/bot-basicbot-pluggable/lib/Bot/BasicBot/Pluggable/Module/ChanOp.pm
line 22.
```
