### PR TITLE
Refactor Karma.pm and add responses to karma changes

### DIFF
--- a/lib/Bot/BasicBot/Pluggable/Module/Karma.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Karma.pm
@@ -60,6 +60,10 @@ sub told {
     $command = lc($command);
 
     if ( $command eq "karma" ) {
+        if ($param eq 'chameleon') {
+            return "Karma karma karma karma karma chameleon, "
+                . "you come and go, you come and go...";
+        }
         $param ||= $mess->{who};
         return "$param has karma of " . $self->get_karma($param) . ".";
     

--- a/lib/Bot/BasicBot/Pluggable/Module/Karma.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Karma.pm
@@ -162,8 +162,8 @@ sub add_karma {
 sub trim_list {
     my ( $self, $list, $count ) = @_;
 
-    # If radomization isn't requested we just return the reasons
-    # in reversed cronological order
+    # If randomization isn't requested we just return the reasons
+    # in reversed chronological order
 
     if ( $self->get('user_randomize_reasons') ) {
         fisher_yates_shuffle($list);

--- a/lib/Bot/BasicBot/Pluggable/Module/Karma.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Karma.pm
@@ -113,11 +113,11 @@ sub maybe_add_giver {
 }
 
 sub get_karma {
-    my ( $self, $object ) = @_;
-    $object = lc($object);
-    $object =~ s/-/ /g;
+    my ( $self, $thing ) = @_;
+    $thing = lc($thing);
+    $thing =~ s/-/ /g;
 
-    my @changes = @{ $self->get("karma_$object") || [] };
+    my @changes = @{ $self->get("karma_$thing") || [] };
 
     my ( @good, @bad );
     my $karma    = 0;
@@ -148,15 +148,15 @@ sub get_karma {
 }
 
 sub add_karma {
-    my ( $self, $object, $good, $reason, $who ) = @_;
-    $object = lc($object);
-    $object =~ s/-/ /g;
+    my ( $self, $thing, $good, $reason, $who ) = @_;
+    $thing = lc($thing);
+    $thing =~ s/-/ /g;
     my $row =
       { reason => $reason, who => $who, timestamp => time, positive => $good };
-    my @changes = @{ $self->get("karma_$object") || [] };
+    my @changes = @{ $self->get("karma_$thing") || [] };
     push @changes, $row;
-    $self->set( "karma_$object" => \@changes );
-    return "Karma for $object is now " . scalar $self->get_karma($object);
+    $self->set( "karma_$thing" => \@changes );
+    return "Karma for $thing is now " . scalar $self->get_karma($thing);
 }
 
 sub trim_list {
@@ -234,12 +234,12 @@ scalar context or a array of hash reference. Every hash reference
 has entries for the timestamp (timestamp), the giver (who) and the
 explanation string (reason) for its karma action.
 
-=item add_karma($object, $good, $reason, $who)
+=item add_karma($thing, $good, $reason, $who)
 
-Adds or subtracts from the passed C<$object>'s karma. C<$good> is either 1 (to
-add a karma point to the C<$object> or 0 (to subtract). C<$reason> is an 
+Adds or subtracts from the passed C<$thing>'s karma. C<$good> is either 1 (to
+add a karma point to the C<$thing> or 0 (to subtract). C<$reason> is an 
 optional string commenting on the reason for the change, and C<$who> is the
-person modifying the karma of C<$object>. Nothing is returned.
+person modifying the karma of C<$thing>. Nothing is returned.
 
 =back
 

--- a/lib/Bot/BasicBot/Pluggable/Module/Karma.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Karma.pm
@@ -160,7 +160,10 @@ sub add_karma {
     my @changes = @{ $self->get("karma_$thing") || [] };
     push @changes, $row;
     $self->set( "karma_$thing" => \@changes );
-    return "Karma for $thing is now " . scalar $self->get_karma($thing);
+    my $respond = $self->get("karma_change_reponse");
+    $respond = 1 if !defined $respond;
+    return $respond ?
+        "Karma for $thing is now " . scalar $self->get_karma($thing) : 1;
 }
 
 sub trim_list {
@@ -206,9 +209,15 @@ Bot::BasicBot::Pluggable::Module::Karma - tracks karma for various concepts
 
 Increases the karma for <thing>.
 
+Responds with the new karma for <thing> unless C<karma_change_response> is set 
+to a false value.
+
 =item <thing>-- # <comment>
 
 Decreases the karma for <thing>.
+
+Responds with the new karma for <thing> unless C<karma_change_response> is set 
+to a false value.
 
 =item karma <thing>
 
@@ -272,6 +281,13 @@ Defaults to 1; whether to randomize the order of reasons. If set
 to 0, the reasons are sorted in reversed chronological order.
 
 =back
+
+=item karma_change_response
+
+Defaults to 1; whether to show a response when the karma of a
+thing is changed.  If true, the bot will reply with the new karma.
+If set to 0, the bot will silently update the karma, without
+a response.
 
 =head1 AUTHOR
 


### PR DESCRIPTION
A refactor of Karma.pm to reduce repetition and tidy it up a bit (IMO, at least).

Also added a response showing new karma score, e.g.:

```
<user> beer++
<bot> Karma for beer is now 1501
```

As part of the refactor, I folded the `seen` and `told` methods down into just `told`, for consolidation and also because `seen` cannot return a reply, as it's called at priority 0 (I think this needs documenting more clearly, actually; I'll do that in another PR.)
