### PR TITLE
Fix for configfile undef error

### DIFF
--- a/lib/App/Bot/BasicBot/Pluggable.pm
+++ b/lib/App/Bot/BasicBot/Pluggable.pm
@@ -74,7 +74,7 @@ has logconfig => ( is => 'rw', isa => 'Str' );
 
 has configfile => (
     is      => 'rw',
-    isa     => 'Str',
+    isa     => 'Str|Undef',
     default => Config::Find->find( name => 'bot-basicbot-pluggable.yaml' ),
 );
 

--- a/lib/Bot/BasicBot/Pluggable.pm
+++ b/lib/Bot/BasicBot/Pluggable.pm
@@ -209,7 +209,7 @@ sub store {
 sub loglevel {
     my $self = shift;
     $self->{loglevel} = shift if @_;
-    return uc $self->{loglevel} || 'WARN';
+    return ($self->{loglevel} and uc $self->{loglevel}) || 'WARN';
 }
 
 sub logconfig {


### PR DESCRIPTION
Hello,

Was trying to run the bot without specifying a config and it was bombing out so added an or undef to the type constraint (also fixed an undef warning that the tests were spewing).

Cheers
Adam
