### PR TITLE
Recognise karma mods at start of line only

### DIFF
--- a/lib/Bot/BasicBot/Pluggable/Module/Karma.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Karma.pm
@@ -37,8 +37,8 @@ sub told {
     my $op_re      = qr{ ( \-\- | \+\+ )        }x;
     my $comment_re = qr{ (?: \s* \# \s* (.+) )? }x;
     for my $regex (
-        qr{   (\w+)    \s* $op_re $comment_re  }x, # singleword++
-        qr{\( (.+)  \) \s* $op_re $comment_re  }x  # (more words)++
+        qr{^   (\w+)     $op_re $comment_re  }x, # singleword++
+        qr{^ \( (.+)  \) $op_re $comment_re  }x  # (more words)++
     ) {
         if (my($thing, $op, $comment) = $body =~ $regex) {
             my $add = $op eq '++' ? 1 : 0;


### PR DESCRIPTION
I've seen far too many instances where it has false-matched in the middle of a
sentence - things like:

```
<user> Oh, you want to use the --foobar option
<bot> Karma for 'the' is now -1
```

or people using two dashes:

```
<user> I like to use two dashes -- like this, for example
<bot> Karma for 'dashes' is now -1
```

I can make this a configurable option if required, but I don't think it's
valuable; everyone I've seen using karma modifiers on IRC does it at the start
of a new line.
