### PR TITLE
Bugfix/seen autoviv

### DIFF
--- a/lib/Bot/BasicBot/Pluggable/Module/Seen.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Seen.pm
@@ -71,7 +71,8 @@ sub told {
         my $seen = $self->get("seen_$who");
     
         my $ignore_channels = $self->get('user_ignore_channels') || {};
-        my $hidden_channel = exists $ignore_channels->{ $seen->{channel} };
+        my $hidden_channel = 
+            $seen && exists $ignore_channels->{ $seen->{channel} };
 
         if ( ( $self->get("user_allow_hiding") and $self->get("hide_$who") )
             or !$seen or $hidden_channel )

--- a/lib/Bot/BasicBot/Pluggable/Module/Seen.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Seen.pm
@@ -74,9 +74,9 @@ sub told {
         my $hidden_channel = 
             $seen && exists $ignore_channels->{ $seen->{channel} };
 
-        if ( ( $self->get("user_allow_hiding") and $self->get("hide_$who") )
-            or !$seen or $hidden_channel )
-        {
+        if (!$seen || $hidden_channel
+            || ( $self->get("user_allow_hiding") and $self->get("hide_$who") )
+        ) {
             return "Sorry, I haven't seen $1.";
         }
 


### PR DESCRIPTION
This silly little bug (my bad, sorry) was causing `$seen` to be autovivified, and thus cause us to falsely report having seen someone when we hadn't.
