### PR TITLE
Ignore links in messages from ourselves.

### DIFF
--- a/lib/Bot/BasicBot/Pluggable/Module/Title.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Title.pm
@@ -28,6 +28,10 @@ sub admin {
     # do this in admin so we always get a chance to see titles
     my ( $self, $mess ) = @_;
 
+    # If the message was from the bot (for e.g. another module announcing the
+    # title of an URL we just said, etc), go no further, to avoid loops
+    return if $mess->{who} eq $self->nick;
+
     my $ignore_regexp = $self->get('user_ignore_re');
 
     my $reply = "";

--- a/lib/Bot/BasicBot/Pluggable/Module/Title.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Title.pm
@@ -30,7 +30,7 @@ sub admin {
 
     # If the message was from the bot (for e.g. another module announcing the
     # title of an URL we just said, etc), go no further, to avoid loops
-    return if $mess->{who} eq $self->nick;
+    return if $mess->{who} eq $self->bot->nick;
 
     my $ignore_regexp = $self->get('user_ignore_re');
 


### PR DESCRIPTION
Don't announce the link title for messages eminating from the bot itself.

Otherwise we have the potential for loops.

For instance, in B::BB::M::P::GItHub::EasyLinks, it recognises a SHA mentioned
in the channel and announces details of that commit, along with the URL.  This
module would see the URL, and announce the page title - which includes the SHA -
which the other module would recognise and show the details for... turtles all
the way down.
