### PR TITLE
Match only "seen \S+"

### DIFF
--- a/lib/Bot/BasicBot/Pluggable/Module/Seen.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Seen.pm
@@ -66,7 +66,7 @@ sub told {
     my ( $command, $param ) = split( /\s+/, $body, 2 );
     $command = lc($command);
 
-    if ( $command eq "seen" and $param =~ /^(.+?)\??$/ ) {
+    if ( $command eq "seen" and $param =~ /^(\S+)\??$/ ) {
         my $who  = lc($1);
         my $seen = $self->get("seen_$who");
     


### PR DESCRIPTION
Avoids sillyness like:

```
10:41 <@lathos> Seen on a friend (who is a JET teacher)'s FB page:
10:41 <+dipsy> Sorry, I haven't seen on a friend (who is a JET teacher)'s FB
               page:.
```
